### PR TITLE
Depend on new libdparse version

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -7,7 +7,7 @@
 	"targetPath": "bin",
 	"targetName": "hmod",
 	"dependencies": {
-		"libdparse": "~master",
+		"libdparse": "~>0.7.0-alpha9",
 		"libddoc": "~master",
 		"dmarkdown": "~>0.2.1"
 	},


### PR DESCRIPTION
Newest dub refused to compile with libdparse ~master version. Instead depend on the latest libdparse version. The resulting binary works fine for me.
