### PR TITLE
Add dmd-nightly and ldc-beta to the Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 language: d
+d:
+  - dmd-nightly
+  - dmd-beta
+  - dmd
+  - ldc-beta
+  - ldc
 sudo: false
 script:
     - dub build


### PR DESCRIPTION
As discussed [here](https://github.com/dlang-community/discussions/issues/7), we can do our share to improve the D ecosystem stability. I have already enabled a daily cron job at Travis, s.t. this doesn't lead to random breakages on new PRs.