### PR TITLE
fix CI failure due to DMD nightly being offline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: d
 d:
-  - dmd-nightly
+  # - dmd-nightly
   - dmd
   - ldc
 sudo: false


### PR DESCRIPTION
It's been offline for over a full month so it's time to deactivate nightlies in the matrix.